### PR TITLE
Correct capitalization of Arduino.h

### DIFF
--- a/src/pms.h
+++ b/src/pms.h
@@ -2,7 +2,7 @@
 #ifndef _PMS_H_
 #define _PMS_H_
 
-#include <arduino.h>
+#include <Arduino.h>
 #include <tribool.h>
 #include <pmsConfig.h>
 

--- a/src/tribool.h
+++ b/src/tribool.h
@@ -1,7 +1,7 @@
 #ifndef _tribool_h_
 #define _tribool_h_
 
-#include <arduino.h>
+#include <Arduino.h>
 
 class tribool;
 


### PR DESCRIPTION
Incorrect capitalization caused compilation to fail on filename case sensitive operating systems such as Linux:
```
fatal error: arduino.h: No such file or directory
```

Fixes https://github.com/jbanaszczyk/pms5003/issues/9