### PR TITLE
WIP: Added support for ESP8266

### DIFF
--- a/src/pms.h
+++ b/src/pms.h
@@ -32,6 +32,12 @@ char(*__countof_helper(_CountofType(&_Array)[_SizeOfArray]))[_SizeOfArray];
 using __uint24 = uint32_t;
 #endif
 
+#if defined ESP8266
+#define MIN_FUNC _min
+#else
+#define MIN_FUNC min
+#endif
+
 ////////////////////////////////////////
 
 namespace pmsx {
@@ -67,7 +73,7 @@ namespace pmsx {
 				"Serial port not initialized",
 				"Status:unknown"
 			};
-			return errorMsg[min(value, _countof(errorMsg))];
+			return errorMsg[MIN_FUNC(value, _countof(errorMsg))];
 		}
 	};
 

--- a/src/pmsConfig.h
+++ b/src/pmsConfig.h
@@ -5,13 +5,19 @@
 // Use one of:
 // it depends on Serial Library (and serial pin connection)
 
+#if defined ESP8266
+#define PMS_SOFTWARESERIAL
+#else
 #define PMS_ALTSOFTSERIAL
+#endif
 
 #if defined PMS_ALTSOFTSERIAL
 // Install https://github.com/DrDiettrich/AltSoftSerial.git)
 #include <pmsSerialAltSoftSerial.h>
+#elif defined PMS_SOFTWARESERIAL
+#include <pmsSerialSoftwareSerial.h>
 #else
-#error "At least one of: [ PMS_ALTSOFTSERIAL ] have to be defined in pmsConfig.h"
+#error "At least one of: [ PMS_ALTSOFTSERIAL PMS_SOFTWARESERIAL ] have to be defined in pmsConfig.h"
 #endif
 
 ////////////////////////////////////////////

--- a/src/pmsSerialSoftwareSerial.h
+++ b/src/pmsSerialSoftwareSerial.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <pmsSerial.h>
+#include <SoftwareSerial.h>
+
+class PmsSoftwareSerial : public IPmsSerial {
+	SoftwareSerial* serial;
+	unsigned long int timeout = 0;
+
+public:
+	PmsSoftwareSerial(SoftwareSerial* iSerial) : serial(iSerial) {}
+
+	void setTimeout(const unsigned long int iTimeout) override {
+		timeout = iTimeout;
+	}
+
+	size_t available() override {
+		return serial->available();
+	}
+
+	bool begin(const uint32_t baudRate) override {
+		serial->begin(baudRate);
+		return true;
+	}
+
+	void end() override {
+		serial->end();
+	}
+
+	void flushInput() override {
+		serial->flush();
+	}
+
+	uint8_t peek() override {
+		return serial->peek();
+	}
+
+	uint8_t read() override {
+		return serial->read();
+	}
+
+	size_t read(uint8_t *buffer, const size_t length) override {
+		unsigned long int readStart = millis();
+		size_t byteRead = 0;
+
+		while (byteRead < length) {
+			int datum = serial->read();
+
+			if (datum == -1){
+				if (millis() - readStart > timeout) {
+					break;
+				}
+				delay(1);
+				continue;
+			}
+
+			buffer[byteRead] = datum;
+			byteRead++;
+		}
+
+		return byteRead;
+	}
+
+	size_t write(const uint8_t *buffer, const size_t size) override {
+		return serial->write(buffer, size);
+	}
+};


### PR DESCRIPTION
Hi!

After finding out that riverscn's fork was reading data at incorrect size, I decided to attempt on adding SoftwareSerial support to this library to support ESP8266

So far it build successfully, but it won't link. I'm not proficient with C++ so I'm posting here in case anyone would know how to fix this:

```
/home/whs/.arduino15/packages/esp8266/tools/xtensa-lx106-elf-gcc/2.5.0-3-20ed2b9/bin/../lib/gcc/xtensa-lx106-elf/4.8.2/../../../../xtensa-lx106-elf/bin/ld: sketch/weatherstation.ino.cpp.o:(.text._ZN17PmsSoftwareSerialD2Ev[PmsSoftwareSerial::~PmsSoftwareSerial()]+0x0): undefined reference to `vtable for IPmsSerial'
```

If I comment out the destructor in `IPmsSerial` then it build just fine, but I feel like that would break something else...